### PR TITLE
uploadprogress corrigido disponivel no repositorio

### DIFF
--- a/containers/app-php8/app-base-php8/assets/install.sh
+++ b/containers/app-php8/app-base-php8/assets/install.sh
@@ -32,15 +32,8 @@ dnf install -y ffmpeg
 
 cd /tmp/assets/pacotes
 
-# InstalaÁ„o do componentes UploadProgress
-tar -zxvf uploadprogress-2.0.2.tgz
-cd uploadprogress-2.0.2
-phpize
-./configure --enable-uploadprogress
-make
-make install
-echo "extension=uploadprogress.so" > /etc/php.d/uploadprogress.ini
-cd -
+# Instala√ß√£o do componentes UploadProgress
+dnf install -y php-pecl-uploadprogress
 
 # fonts libraries
 rpm -Uvh msttcore-fonts-2.0-3.noarch.rpm


### PR DESCRIPTION
Alterei o arquivo de instalação do container docker  app-base-php8 para usar o uploadprogress diretamente pelo dnf ao invés de compilar os fontes. Este é o que está sendo usado no TRF4.