### PR TITLE
Correção usuário padrão SEI_USER e SIP_USER para o mysql_native_password

### DIFF
--- a/containers/databases/mysql8-sei41/assets/pre-install.sql
+++ b/containers/databases/mysql8-sei41/assets/pre-install.sql
@@ -2,13 +2,13 @@
 CREATE DATABASE sei;
 
 USE sei;
-CREATE USER 'sei_user'@'%' IDENTIFIED BY 'sei_user';
+CREATE USER 'sei_user'@'%' IDENTIFIED WITH mysql_native_password BY 'sei_user';
 GRANT ALL PRIVILEGES ON sei.* TO 'sei_user'@'%';
 
 
 CREATE DATABASE sip;
 
 USE sip;
-CREATE USER 'sip_user'@'%' IDENTIFIED BY 'sip_user';
+CREATE USER 'sip_user'@'%' IDENTIFIED WITH mysql_native_password BY 'sip_user';
 GRANT ALL PRIVILEGES ON sip.* TO 'sip_user'@'%';
 


### PR DESCRIPTION
A alteração corrige o acesso ao banco MYSQL 8 do sistema SEI  com o PHP 7.3, usando o plugin de autenticação mysql_native_password.

A correção é aplicada ao serem criados os usuários padrão de banco "sei_user" e "sip_user".